### PR TITLE
tox.ini: mitigate version incompatibility between coveralls and coverage 5.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,8 @@ deps=
     repeated_test
     py26: ordereddict
     py26,py27,py32,pypy: funcsigs>=0.4
-    cover,coveralls: coverage
+    cover: coverage
+    coveralls: coverage<5.0
     coveralls: coveralls
 
 commands=


### PR DESCRIPTION
Pinned coverage<5.0 in coveralls workflow while coveralls-clients/coveralls-python#203 gets addressed.