### PR TITLE
parameters are now upgraded with information to support postponed annotations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+url = "https://pypi.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[packages]
+repeated-test = {editable = true, path = "./../repeated_test"}
+pytest = "*"
+sigtools = {editable = true, extras = ["test"], path = "."}
+pytest-subtests = "*"
+
+[dev-packages]
+
+[requires]
+python_version = "3.10"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,369 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "96c8ea70ce35700e96ea8c598e632ef0a3135ba66fd967999f3caedda1d491cc"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.10"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "alabaster": {
+            "hashes": [
+                "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359",
+                "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"
+            ],
+            "version": "==0.7.12"
+        },
+        "attrs": {
+            "hashes": [
+                "sha256:2d27e3784d7a565d36ab851fe94887c5eccd6a463168875832a1be79c82828b4",
+                "sha256:626ba8234211db98e869df76230a137c4c40a12d72445c45d5f5b716f076e2fd"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==21.4.0"
+        },
+        "babel": {
+            "hashes": [
+                "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51",
+                "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.10.3"
+        },
+        "certifi": {
+            "hashes": [
+                "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d",
+                "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.6.15"
+        },
+        "charset-normalizer": {
+            "hashes": [
+                "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5",
+                "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.1.0"
+        },
+        "coverage": {
+            "hashes": [
+                "sha256:01c5615d13f3dd3aa8543afc069e5319cfa0c7d712f6e04b920431e5c564a749",
+                "sha256:106c16dfe494de3193ec55cac9640dd039b66e196e4641fa8ac396181578b982",
+                "sha256:129cd05ba6f0d08a766d942a9ed4b29283aff7b2cccf5b7ce279d50796860bb3",
+                "sha256:145f296d00441ca703a659e8f3eb48ae39fb083baba2d7ce4482fb2723e050d9",
+                "sha256:1480ff858b4113db2718848d7b2d1b75bc79895a9c22e76a221b9d8d62496428",
+                "sha256:269eaa2c20a13a5bf17558d4dc91a8d078c4fa1872f25303dddcbba3a813085e",
+                "sha256:26dff09fb0d82693ba9e6231248641d60ba606150d02ed45110f9ec26404ed1c",
+                "sha256:2bd9a6fc18aab8d2e18f89b7ff91c0f34ff4d5e0ba0b33e989b3cd4194c81fd9",
+                "sha256:309ce4a522ed5fca432af4ebe0f32b21d6d7ccbb0f5fcc99290e71feba67c264",
+                "sha256:3384f2a3652cef289e38100f2d037956194a837221edd520a7ee5b42d00cc605",
+                "sha256:342d4aefd1c3e7f620a13f4fe563154d808b69cccef415415aece4c786665397",
+                "sha256:39ee53946bf009788108b4dd2894bf1349b4e0ca18c2016ffa7d26ce46b8f10d",
+                "sha256:4321f075095a096e70aff1d002030ee612b65a205a0a0f5b815280d5dc58100c",
+                "sha256:4803e7ccf93230accb928f3a68f00ffa80a88213af98ed338a57ad021ef06815",
+                "sha256:4ce1b258493cbf8aec43e9b50d89982346b98e9ffdfaae8ae5793bc112fb0068",
+                "sha256:664a47ce62fe4bef9e2d2c430306e1428ecea207ffd68649e3b942fa8ea83b0b",
+                "sha256:75ab269400706fab15981fd4bd5080c56bd5cc07c3bccb86aab5e1d5a88dc8f4",
+                "sha256:83c4e737f60c6936460c5be330d296dd5b48b3963f48634c53b3f7deb0f34ec4",
+                "sha256:84631e81dd053e8a0d4967cedab6db94345f1c36107c71698f746cb2636c63e3",
+                "sha256:84e65ef149028516c6d64461b95a8dbcfce95cfd5b9eb634320596173332ea84",
+                "sha256:865d69ae811a392f4d06bde506d531f6a28a00af36f5c8649684a9e5e4a85c83",
+                "sha256:87f4f3df85aa39da00fd3ec4b5abeb7407e82b68c7c5ad181308b0e2526da5d4",
+                "sha256:8c08da0bd238f2970230c2a0d28ff0e99961598cb2e810245d7fc5afcf1254e8",
+                "sha256:961e2fb0680b4f5ad63234e0bf55dfb90d302740ae9c7ed0120677a94a1590cb",
+                "sha256:9b3e07152b4563722be523e8cd0b209e0d1a373022cfbde395ebb6575bf6790d",
+                "sha256:a7f3049243783df2e6cc6deafc49ea123522b59f464831476d3d1448e30d72df",
+                "sha256:bf5601c33213d3cb19d17a796f8a14a9eaa5e87629a53979a5981e3e3ae166f6",
+                "sha256:cec3a0f75c8f1031825e19cd86ee787e87cf03e4fd2865c79c057092e69e3a3b",
+                "sha256:d42c549a8f41dc103a8004b9f0c433e2086add8a719da00e246e17cbe4056f72",
+                "sha256:d67d44996140af8b84284e5e7d398e589574b376fb4de8ccd28d82ad8e3bea13",
+                "sha256:d9c80df769f5ec05ad21ea34be7458d1dc51ff1fb4b2219e77fe24edf462d6df",
+                "sha256:e57816f8ffe46b1df8f12e1b348f06d164fd5219beba7d9433ba79608ef011cc",
+                "sha256:ee2ddcac99b2d2aec413e36d7a429ae9ebcadf912946b13ffa88e7d4c9b712d6",
+                "sha256:f02cbbf8119db68455b9d763f2f8737bb7db7e43720afa07d8eb1604e5c5ae28",
+                "sha256:f1d5aa2703e1dab4ae6cf416eb0095304f49d004c39e9db1d86f57924f43006b",
+                "sha256:f5b66caa62922531059bc5ac04f836860412f7f88d38a476eda0a6f11d4724f4",
+                "sha256:f69718750eaae75efe506406c490d6fc5a6161d047206cc63ce25527e8a3adad",
+                "sha256:fb73e0011b8793c053bfa85e53129ba5f0250fdc0392c1591fd35d915ec75c46",
+                "sha256:fd180ed867e289964404051a958f7cccabdeed423f91a899829264bb7974d3d3",
+                "sha256:fdb6f7bd51c2d1714cea40718f6149ad9be6a2ee7d93b19e9f00934c0f2a74d9",
+                "sha256:ffa9297c3a453fba4717d06df579af42ab9a28022444cae7fa605af4df612d54"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==6.4.1"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c",
+                "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==0.18.1"
+        },
+        "idna": {
+            "hashes": [
+                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
+                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==3.3"
+        },
+        "imagesize": {
+            "hashes": [
+                "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b",
+                "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.4.1"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852",
+                "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.1.2"
+        },
+        "markupsafe": {
+            "hashes": [
+                "sha256:0212a68688482dc52b2d45013df70d169f542b7394fc744c02a57374a4207003",
+                "sha256:089cf3dbf0cd6c100f02945abeb18484bd1ee57a079aefd52cffd17fba910b88",
+                "sha256:10c1bfff05d95783da83491be968e8fe789263689c02724e0c691933c52994f5",
+                "sha256:33b74d289bd2f5e527beadcaa3f401e0df0a89927c1559c8566c066fa4248ab7",
+                "sha256:3799351e2336dc91ea70b034983ee71cf2f9533cdff7c14c90ea126bfd95d65a",
+                "sha256:3ce11ee3f23f79dbd06fb3d63e2f6af7b12db1d46932fe7bd8afa259a5996603",
+                "sha256:421be9fbf0ffe9ffd7a378aafebbf6f4602d564d34be190fc19a193232fd12b1",
+                "sha256:43093fb83d8343aac0b1baa75516da6092f58f41200907ef92448ecab8825135",
+                "sha256:46d00d6cfecdde84d40e572d63735ef81423ad31184100411e6e3388d405e247",
+                "sha256:4a33dea2b688b3190ee12bd7cfa29d39c9ed176bda40bfa11099a3ce5d3a7ac6",
+                "sha256:4b9fe39a2ccc108a4accc2676e77da025ce383c108593d65cc909add5c3bd601",
+                "sha256:56442863ed2b06d19c37f94d999035e15ee982988920e12a5b4ba29b62ad1f77",
+                "sha256:671cd1187ed5e62818414afe79ed29da836dde67166a9fac6d435873c44fdd02",
+                "sha256:694deca8d702d5db21ec83983ce0bb4b26a578e71fbdbd4fdcd387daa90e4d5e",
+                "sha256:6a074d34ee7a5ce3effbc526b7083ec9731bb3cbf921bbe1d3005d4d2bdb3a63",
+                "sha256:6d0072fea50feec76a4c418096652f2c3238eaa014b2f94aeb1d56a66b41403f",
+                "sha256:6fbf47b5d3728c6aea2abb0589b5d30459e369baa772e0f37a0320185e87c980",
+                "sha256:7f91197cc9e48f989d12e4e6fbc46495c446636dfc81b9ccf50bb0ec74b91d4b",
+                "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812",
+                "sha256:8dc1c72a69aa7e082593c4a203dcf94ddb74bb5c8a731e4e1eb68d031e8498ff",
+                "sha256:8e3dcf21f367459434c18e71b2a9532d96547aef8a871872a5bd69a715c15f96",
+                "sha256:8e576a51ad59e4bfaac456023a78f6b5e6e7651dcd383bcc3e18d06f9b55d6d1",
+                "sha256:96e37a3dc86e80bf81758c152fe66dbf60ed5eca3d26305edf01892257049925",
+                "sha256:97a68e6ada378df82bc9f16b800ab77cbf4b2fada0081794318520138c088e4a",
+                "sha256:99a2a507ed3ac881b975a2976d59f38c19386d128e7a9a18b7df6fff1fd4c1d6",
+                "sha256:a49907dd8420c5685cfa064a1335b6754b74541bbb3706c259c02ed65b644b3e",
+                "sha256:b09bf97215625a311f669476f44b8b318b075847b49316d3e28c08e41a7a573f",
+                "sha256:b7bd98b796e2b6553da7225aeb61f447f80a1ca64f41d83612e6139ca5213aa4",
+                "sha256:b87db4360013327109564f0e591bd2a3b318547bcef31b468a92ee504d07ae4f",
+                "sha256:bcb3ed405ed3222f9904899563d6fc492ff75cce56cba05e32eff40e6acbeaa3",
+                "sha256:d4306c36ca495956b6d568d276ac11fdd9c30a36f1b6eb928070dc5360b22e1c",
+                "sha256:d5ee4f386140395a2c818d149221149c54849dfcfcb9f1debfe07a8b8bd63f9a",
+                "sha256:dda30ba7e87fbbb7eab1ec9f58678558fd9a6b8b853530e176eabd064da81417",
+                "sha256:e04e26803c9c3851c931eac40c695602c6295b8d432cbe78609649ad9bd2da8a",
+                "sha256:e1c0b87e09fa55a220f058d1d49d3fb8df88fbfab58558f1198e08c1e1de842a",
+                "sha256:e72591e9ecd94d7feb70c1cbd7be7b3ebea3f548870aa91e2732960fa4d57a37",
+                "sha256:e8c843bbcda3a2f1e3c2ab25913c80a3c5376cd00c6e8c4a86a89a28c8dc5452",
+                "sha256:efc1913fd2ca4f334418481c7e595c00aad186563bbc1ec76067848c7ca0a933",
+                "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
+                "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.1.1"
+        },
+        "mock": {
+            "hashes": [
+                "sha256:122fcb64ee37cfad5b3f48d7a7d51875d7031aaf3d8be7c42e2bee25044eee62",
+                "sha256:7d3fbbde18228f4ff2f1f119a45cdffa458b4c0dee32eb4d2bb2f82554bac7bc"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==4.0.3"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
+                "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==21.3"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159",
+                "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==1.0.0"
+        },
+        "py": {
+            "hashes": [
+                "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719",
+                "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==1.11.0"
+        },
+        "pygments": {
+            "hashes": [
+                "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb",
+                "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.12.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
+                "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
+            ],
+            "markers": "python_full_version >= '3.6.8'",
+            "version": "==3.0.9"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:13d0e3ccfc2b6e26be000cb6568c832ba67ba32e719443bfe725814d3c42433c",
+                "sha256:a06a0425453864a270bc45e71f783330a7428defb4230fb5e6a731fde06ecd45"
+            ],
+            "index": "pypi",
+            "version": "==7.1.2"
+        },
+        "pytest-subtests": {
+            "hashes": [
+                "sha256:46eb376022e926950816ccc23502de3277adcc1396652ddb3328ce0289052c4d",
+                "sha256:4e28ca52cf7a46645c1ded7933745b69334cdc97a412ed4431f7be7cef9a0994"
+            ],
+            "index": "pypi",
+            "version": "==0.8.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7",
+                "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"
+            ],
+            "version": "==2022.1"
+        },
+        "repeated-test": {
+            "editable": true,
+            "path": "./../repeated_test"
+        },
+        "requests": {
+            "hashes": [
+                "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
+                "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
+            ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
+            "version": "==2.28.1"
+        },
+        "sigtools": {
+            "editable": true,
+            "extras": [
+                "test"
+            ],
+            "path": "."
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "snowballstemmer": {
+            "hashes": [
+                "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1",
+                "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"
+            ],
+            "version": "==2.2.0"
+        },
+        "sphinx": {
+            "hashes": [
+                "sha256:b18e978ea7565720f26019c702cd85c84376e948370f1cd43d60265010e1c7b0",
+                "sha256:d3e57663eed1d7c5c50895d191fdeda0b54ded6f44d5621b50709466c338d1e8"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==5.0.2"
+        },
+        "sphinxcontrib-applehelp": {
+            "hashes": [
+                "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a",
+                "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.2"
+        },
+        "sphinxcontrib-devhelp": {
+            "hashes": [
+                "sha256:8165223f9a335cc1af7ffe1ed31d2871f325254c0423bc0c4c7cd1c1e4734a2e",
+                "sha256:ff7f1afa7b9642e7060379360a67e9c41e8f3121f2ce9164266f61b9f4b338e4"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.2"
+        },
+        "sphinxcontrib-htmlhelp": {
+            "hashes": [
+                "sha256:d412243dfb797ae3ec2b59eca0e52dac12e75a241bf0e4eb861e450d06c6ed07",
+                "sha256:f5f8bb2d0d629f398bf47d0d69c07bc13b65f75a81ad9e2f71a63d4b7a2f6db2"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==2.0.0"
+        },
+        "sphinxcontrib-jsmath": {
+            "hashes": [
+                "sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178",
+                "sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.1"
+        },
+        "sphinxcontrib-qthelp": {
+            "hashes": [
+                "sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72",
+                "sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.0.3"
+        },
+        "sphinxcontrib-serializinghtml": {
+            "hashes": [
+                "sha256:352a9a00ae864471d3a7ead8d7d79f5fc0b57e8b3f95e9867eb9eb28999b92fd",
+                "sha256:aa5f6de5dfdf809ef505c4895e51ef5c9eac17d0f287933eb49ec495280b6952"
+            ],
+            "markers": "python_version >= '3.5'",
+            "version": "==1.1.5"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14",
+                "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
+            "version": "==1.26.9"
+        }
+    },
+    "develop": {}
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal=1
 
 [upload_docs]
-upload-dir = build/sphinx/html
+upload_dir = build/sphinx/html

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.rst") as fh:
     long_description = fh.read()
 
 tests_deps = [
-    'repeated_test>=2.1.3',
+    'repeated_test>=2.2.1',
     'sphinx',
     'mock',
     'coverage',
@@ -23,7 +23,7 @@ setup(
     url='https://sigtools.readthedocs.io/',
     packages=['sigtools', 'sigtools.tests'],
     tests_require=tests_deps,
-    install_requires=[],
+    install_requires=['attrs'],
     python_requires='>=3.6',
     extras_require={
         'test': tests_deps,

--- a/sigtools/_autoforwards.py
+++ b/sigtools/_autoforwards.py
@@ -380,9 +380,10 @@ def forward_signatures(func, calls, args, kwargs, sig):
             ausig = _signatures.forwards(
                 sig, wrapped_sig,
                 len(fwdargs) - using_partial,
-                hide_args, hide_kwargs,
-                use_varargs, use_varkwargs,
-                using_partial, *fwdkwargs)
+                *fwdkwargs,
+                hide_args=hide_args, hide_kwargs=hide_kwargs,
+                use_varargs=use_varargs, use_varkwargs=use_varkwargs,
+                partial=using_partial)
             yield ausig
         except ValueError:
             raise UnknownForwards

--- a/sigtools/_signatures.py
+++ b/sigtools/_signatures.py
@@ -100,21 +100,6 @@ class _EmptyAnnotation(UpgradedAnnotation):
         return "EmptyAnnotation"
 EmptyAnnotation: UpgradedAnnotation = _EmptyAnnotation()
 
-def _assert_all_parameters_upgraded(parameters):
-    if not all(
-        isinstance(param, UpgradedParameter) for param in parameters
-    ):
-        raise ValueError(
-            f"UpgradedSignature must be instantiated with UpgradedParameter parameters, received {_first_not_upgraded_paramater(parameters)!r}"
-            )
-
-
-def _first_not_upgraded_paramater(parameters):
-    for param in parameters:
-        if not isinstance(param, UpgradedParameter):
-            return param
-    raise ValueError("all params upgraded")
-
 
 class UpgradedSignature(_util.funcsigs.Signature):
     __slots__ = _util.funcsigs.Signature.__slots__ + ('sources', 'upgraded_return_annotation')
@@ -175,7 +160,10 @@ class UpgradedSignature(_util.funcsigs.Signature):
         return ret
 
     def evaluated(self):
-        return self.replace(return_annotation=self.upgraded_return_annotation.value())
+        return self.replace(
+            parameters=[param.evaluated() for param in self.parameters.values()],
+            return_annotation=self.upgraded_return_annotation.value(),
+        )
 
     def __eq__(self, other):
         if not super().__eq__(other):

--- a/sigtools/_signatures.py
+++ b/sigtools/_signatures.py
@@ -19,42 +19,244 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 # THE SOFTWARE.
 
+import __future__
+import abc
+from itertools import zip_longest
 import itertools
 import collections
 from functools import partial
+import typing
+import warnings
+
+import attr
 
 from sigtools import _util
 
-try:
-    zip_longest = itertools.izip_longest
-except AttributeError: # pragma: no cover
-    zip_longest = itertools.zip_longest
 
+class UpgradedAnnotation(metaclass=abc.ABCMeta):
+    @classmethod
+    def upgrade(cls, raw_annotation, function, *, _stacklevel=0) -> 'UpgradedAnnotation':
+        if raw_annotation is UpgradedParameter.empty:
+            return EmptyAnnotation
 
-class Signature(_util.funcsigs.Signature):
-    __slots__ = _util.funcsigs.Signature.__slots__ + ('sources',)
+        if not function:
+            warnings.warn(
+                "No function provided when upgrading annotation",
+                DeprecationWarning,
+                stacklevel=_stacklevel + 1
+            )
+            return EmptyAnnotation
 
-    def __init__(self, *args, **kwargs):
-        self.sources = kwargs.pop('sources', {})
-        super(Signature, self).__init__(*args, **kwargs)
+        feature = getattr(__future__, "annotations", None)
+        if feature and function.__code__.co_flags & feature.compiler_flag:
+            return PostponedAnnotation(raw_annotation, function)
+
+        return PreEvaluatedAnnotation(raw_annotation)
 
     @classmethod
-    def upgrade(cls, inst, sources):
+    def preevaluated(cls, value) -> 'UpgradedAnnotation':
+        if value is UpgradedParameter.empty:
+            return EmptyAnnotation
+        return PreEvaluatedAnnotation(value)
+
+    @abc.abstractmethod
+    def value(self):
+        raise NotImplementedError
+
+    def __eq__(self, other):
+        if isinstance(other, UpgradedAnnotation):
+            return self.value() == other.value()
+        return False
+
+
+@attr.define(eq=False)
+class PostponedAnnotation(UpgradedAnnotation):
+    """An annotation whose evaluation was postponed per :PEP:`563`"""
+
+    raw_annotation: typing.Any
+    function: typing.Callable
+
+    def value(self):
+        return eval(self.raw_annotation, self.function.__globals__, {})
+
+
+@attr.define(eq=False)
+class PreEvaluatedAnnotation(UpgradedAnnotation):
+    """An annotation that was already evaluated"""
+
+    annotation: typing.Any
+
+    def value(self):
+        return self.annotation
+
+
+class _EmptyAnnotation(UpgradedAnnotation):
+    """An annotation that was not supplied"""
+
+    def value(self):
+        return UpgradedParameter.empty
+
+    def __repr__(self):
+        return "EmptyAnnotation"
+EmptyAnnotation: UpgradedAnnotation = _EmptyAnnotation()
+
+def _assert_all_parameters_upgraded(parameters):
+    if not all(
+        isinstance(param, UpgradedParameter) for param in parameters
+    ):
+        raise ValueError(
+            f"UpgradedSignature must be instantiated with UpgradedParameter parameters, received {_first_not_upgraded_paramater(parameters)!r}"
+            )
+
+
+def _first_not_upgraded_paramater(parameters):
+    for param in parameters:
+        if not isinstance(param, UpgradedParameter):
+            return param
+    raise ValueError("all params upgraded")
+
+
+class UpgradedSignature(_util.funcsigs.Signature):
+    __slots__ = _util.funcsigs.Signature.__slots__ + ('sources', 'upgraded_return_annotation')
+
+    def __init__(self, parameters=None, *args, upgraded_return_annotation=EmptyAnnotation, _stacklevel=0, **kwargs):
+        self.sources = kwargs.pop('sources', {})
+        self.upgraded_return_annotation = upgraded_return_annotation
+        parameters = _upgrade_parameters_with_warning(parameters, stacklevel=_stacklevel + 1)
+        super(Signature, self).__init__(parameters, *args, **kwargs)
+
+    @classmethod
+    def upgrade(cls, inst, function, sources, *, _stacklevel=0):
         if isinstance(inst, cls):
             return inst
+        params = [
+            UpgradedParameter.upgrade(param, function, sources)
+            for param in inst.parameters.values()
+        ]
         return cls(
-            inst.parameters.values(),
+            params,
             return_annotation=inst.return_annotation,
-            sources=sources)
+            upgraded_return_annotation=UpgradedAnnotation.upgrade(inst.return_annotation, function),
+            sources=sources,
+            _stacklevel=_stacklevel,
+        )
 
-    def replace(self, *args, **kwargs):
+    @classmethod
+    def _upgrade_with_warning(cls, inst, *, _stacklevel=0):
+        if isinstance(inst, cls):
+            return inst
+        warnings.warn(
+            "inspect.Signature instances passed to sigtools "
+            "must be upgraded with sigtools.Signature.upgrade",
+            DeprecationWarning,
+            stacklevel=_stacklevel + 2,
+        )
+        return cls.upgrade(inst, None, {})
+
+    def replace(self, *args, _stacklevel=0, **kwargs):
         try:
             sources = kwargs.pop('sources')
         except KeyError:
             sources = self.sources
-        ret = super(Signature, self).replace(*args, **kwargs)
+        try:
+            parameters = kwargs.pop('parameters')
+        except KeyError:
+            parameters = self.parameters.values()
+        else:
+            parameters = _upgrade_parameters_with_warning(parameters, stacklevel=_stacklevel + 1)
+        try:
+            upgraded_return_annotation = kwargs.pop("upgraded_return_annotation")
+        except KeyError:
+            upgraded_return_annotation = self.upgraded_return_annotation
+        ret = super().replace(*args, parameters=parameters, **kwargs)
+        assert isinstance(ret, type(self))
         ret.sources = sources
+        ret.upgraded_return_annotation = upgraded_return_annotation
         return ret
+
+    def evaluated(self):
+        return self.replace(return_annotation=self.upgraded_return_annotation.value())
+
+    def __eq__(self, other):
+        if not super().__eq__(other):
+            return False
+        return self.upgraded_return_annotation == other.upgraded_return_annotation
+
+
+Signature = UpgradedSignature
+
+
+class UpgradedParameter(_util.funcsigs.Parameter):
+    __slots__ = _util.funcsigs.Parameter.__slots__ + ('upgraded_annotation', 'function', 'sources', "source_depths")
+
+    @classmethod
+    def upgrade(cls, inst, function, function_sources):
+        if isinstance(inst, cls):
+            return inst
+        sources = function_sources.get(inst.name, [])
+        source_depths = {
+            func: depth
+            for func, depth in function_sources.get("+depths", {}).items()
+            if func in sources
+        }
+        return cls(
+            name=inst.name,
+            kind=inst.kind,
+            default=inst.default,
+            annotation=inst.annotation,
+            upgraded_annotation=UpgradedAnnotation.upgrade(inst.annotation, function),
+            function=function,
+            sources=sources,
+            source_depths=source_depths,
+        )
+
+    def __init__(self, *args, function=None, sources=[], source_depths={}, upgraded_annotation=EmptyAnnotation, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.function = function
+        self.sources = sources
+        self.source_depths = source_depths
+        self.upgraded_annotation = upgraded_annotation
+
+    def replace(self, function=_util.UNSET, sources=_util.UNSET, source_depths=_util.UNSET, upgraded_annotation=_util.UNSET, **kwargs):
+        function = self.function if function is _util.UNSET else function
+        sources = self.sources if sources is _util.UNSET else sources
+        source_depths = self.source_depths if source_depths is _util.UNSET else source_depths
+        upgraded_annotation = self.upgraded_annotation if upgraded_annotation is _util.UNSET else upgraded_annotation
+
+        ret = super().replace(**kwargs)
+        assert isinstance(ret, type(self))
+        ret.function = function
+        ret.sources = sources
+        ret.source_depths = source_depths
+        ret.upgraded_annotation = upgraded_annotation
+        return ret
+
+    def evaluated(self):
+        return self.replace(annotation=self.upgraded_annotation.value())
+
+    def __eq__(self, other):
+        if not super().__eq__(other):
+            return False
+        return self.upgraded_annotation == other.upgraded_annotation
+
+
+def _upgrade_parameters_with_warning(parameters, stacklevel=1):
+    if parameters is None:
+        return None
+    if all(isinstance(param, UpgradedParameter) for param in parameters):
+        return parameters
+    else:
+        warnings.warn(
+            "inspect.Signature and Parameter instances "
+            "passed to sigtools should be upgraded "
+            "to sigtools.UpgradedSignature and UpgradedParameter",
+            DeprecationWarning,
+            stacklevel=2 + stacklevel
+        )
+        return [
+            UpgradedParameter.upgrade(param, function=None, function_sources={})
+            for param in parameters
+        ]
 
 
 def default_sources(sig, obj):
@@ -65,7 +267,7 @@ def default_sources(sig, obj):
 
 def set_default_sources(sig, obj):
     """Assigns the source of every parameter of sig to obj"""
-    return Signature.upgrade(sig, default_sources(sig, obj))
+    return Signature.upgrade(sig, obj, default_sources(sig, obj))
 
 
 def signature(obj):
@@ -98,10 +300,10 @@ SortedParameters = collections.namedtuple(
     'posargs pokargs varargs kwoargs varkwargs sources')
 
 
-def sort_params(sig, sources=False):
+def sort_params(sig, sources=False, _stacklevel=0):
     """Classifies the parameters from sig.
 
-    :param inspect.Signature sig: The signature to operate on
+    :param UpgradedSignature sig: The signature to operate on
 
     :returns: A tuple ``(posargs, pokargs, varargs, kwoargs, varkwas)``
     :rtype: ``(list, list, Parameter or None, dict, Parameter or None)``
@@ -119,6 +321,8 @@ def sort_params(sig, sources=False):
          None)
 
     """
+    sig = UpgradedSignature._upgrade_with_warning(sig, _stacklevel=_stacklevel + 1)
+    assert isinstance(sig, UpgradedSignature), "signature must be upgraded"
     posargs = []
     pokargs = []
     varargs = None
@@ -146,12 +350,13 @@ def sort_params(sig, sources=False):
 
 
 def apply_params(sig, posargs, pokargs, varargs, kwoargs, varkwargs,
-                 sources=None):
+                 sources=None, function=None, *, _stacklevel=0):
     """Reverses `sort_params`'s operation.
 
     :returns: A new `inspect.Signature` object based off sig,
         with the given parameters.
     """
+    sig = UpgradedSignature._upgrade_with_warning(sig, _stacklevel=_stacklevel + 1)
     parameters = []
     parameters.extend(posargs)
     parameters.extend(pokargs)
@@ -160,9 +365,9 @@ def apply_params(sig, posargs, pokargs, varargs, kwoargs, varkwargs,
     parameters.extend(kwoargs.values())
     if varkwargs:
         parameters.append(varkwargs)
-    sig = sig.replace(parameters=parameters)
+    sig = sig.replace(parameters=parameters, _stacklevel=_stacklevel + 1)
     if sources is not None:
-        sig = Signature.upgrade(sig, sources)
+        sig = Signature.upgrade(sig, function, sources, _stacklevel=1)
         sig.sources = sources
     return sig
 
@@ -417,14 +622,18 @@ class _Merger(object):
                 # actual default in the function body
                 default = None
         annotation = left.empty
+        upgraded_annotation = EmptyAnnotation
         if left.annotation != left.empty and right.annotation != right.empty:
             if left.annotation == right.annotation:
                 annotation = left.annotation
+                upgraded_annotation = left.upgraded_annotation
         elif left.annotation != left.empty:
             annotation = left.annotation
+            upgraded_annotation = left.upgraded_annotation
         elif right.annotation != right.empty:
             annotation = right.annotation
-        return left.replace(default=default, annotation=annotation)
+            upgraded_annotation = right.upgraded_annotation
+        return left.replace(default=default, annotation=annotation, upgraded_annotation=upgraded_annotation)
 
 
 def merge(*signatures):
@@ -436,7 +645,7 @@ def merge(*signatures):
     conform to the merged signature may actually work on all the given ones
     regardless.
 
-    :param inspect.Signature signatures: The signatures to merge together.
+    :param sigtools.UpgradedSignature signatures: The signatures to merge together.
 
     :returns: a `inspect.Signature` object
     :raises: `IncompatibleSignatures`
@@ -485,14 +694,14 @@ def merge(*signatures):
 
     """
     assert signatures, "Expected at least one signature"
-    ret = sort_params(signatures[0], sources=True)
+    ret = sort_params(signatures[0], sources=True, _stacklevel=1)
     for i, sig in enumerate(signatures[1:], 1):
-        sorted_params = sort_params(sig, sources=True)
+        sorted_params = sort_params(sig, sources=True, _stacklevel=1)
         try:
             ret = SortedParameters(*_Merger(ret, sorted_params))
         except ValueError:
             raise IncompatibleSignatures(sig, signatures[:i])
-    ret_sig = apply_params(signatures[0], *ret)
+    ret_sig = apply_params(signatures[0], *ret, _stacklevel=1)
     return ret_sig
 
 
@@ -565,7 +774,7 @@ def _embed(outer, inner, use_varargs=True, use_varkwargs=True, depth=1):
         src
         )
 
-def embed(use_varargs=True, use_varkwargs=True, *signatures):
+def embed(*signatures, use_varargs=True, use_varkwargs=True, _stacklevel=0):
     """Embeds a signature within another's ``*args`` and ``**kwargs``
     parameters, as if a function with the outer signature called a function with
     the inner signature with just ``f(*args, **kwargs)``.
@@ -596,14 +805,14 @@ def embed(use_varargs=True, use_varkwargs=True, *signatures):
         (self, *args, keyword, **kwargs)
     """
     assert signatures
-    ret = sort_params(signatures[0], sources=True)
+    ret = sort_params(signatures[0], sources=True, _stacklevel=_stacklevel + 1)
     for i, sig in enumerate(signatures[1:], 1):
         try:
-            ret = _embed(ret, sort_params(sig, sources=True),
+            ret = _embed(ret, sort_params(sig, sources=True, _stacklevel=_stacklevel + 1),
                          use_varargs, use_varkwargs, i)
         except ValueError:
             raise IncompatibleSignatures(sig, signatures[:i])
-    return apply_params(signatures[0], *ret)
+    return apply_params(signatures[0], *ret, _stacklevel=_stacklevel + 1)
 
 
 def _pop_chain(*sequences):
@@ -623,9 +832,10 @@ def _pnames(ita):
 
 
 def _mask(sig, num_args, hide_args, hide_kwargs,
-          hide_varargs, hide_varkwargs, named_args, partial_obj):
+          hide_varargs, hide_varkwargs, named_args, partial_obj,
+          *, _stacklevel=0):
     posargs, pokargs, varargs, kwoargs, varkwargs, src \
-        = sort_params(sig, sources=True)
+        = sort_params(sig, sources=True, _stacklevel=_stacklevel + 1)
 
     pokargs_by_name = dict((p.name, p) for p in pokargs)
     consumed_names = set()
@@ -696,7 +906,7 @@ def _mask(sig, num_args, hide_args, hide_kwargs,
                 'Named parameter {0!r} not found in signature: {1}'
                 .format(kwarg_name, sig))
         elif partial_mode:
-            kwoargs[kwarg_name] = _util.funcsigs.Parameter(
+            kwoargs[kwarg_name] = UpgradedParameter(
                 kwarg_name, _util.funcsigs.Parameter.KEYWORD_ONLY,
                 default=named_args[kwarg_name])
             src[kwarg_name] = [partial_obj]
@@ -710,14 +920,16 @@ def _mask(sig, num_args, hide_args, hide_kwargs,
     if partial_mode:
         src = copy_sources(src, increase=True)
         src['+depths'][partial_obj] = 0
-    ret = apply_params(sig, posargs, pokargs, varargs, kwoargs, varkwargs, src)
+    ret = apply_params(sig, posargs, pokargs, varargs, kwoargs, varkwargs, src, _stacklevel=_stacklevel + 1)
     return ret
 
 
 def mask(sig, num_args=0,
+         *named_args,
          hide_args=False, hide_kwargs=False,
          hide_varargs=False, hide_varkwargs=False,
-         *named_args):
+         _stacklevel=0
+         ):
     """Removes the given amount of positional parameters and the given named
     parameters from ``sig``.
 
@@ -746,13 +958,14 @@ def mask(sig, num_args=0,
 
     """
     return _mask(sig, num_args, hide_args, hide_kwargs,
-                 hide_varargs, hide_varkwargs, named_args, None)
+                 hide_varargs, hide_varkwargs, named_args, None, _stacklevel=_stacklevel + 1)
 
 
 def forwards(outer, inner, num_args=0,
+             *named_args,
              hide_args=False, hide_kwargs=False,
              use_varargs=True, use_varkwargs=True,
-             partial=False, *named_args):
+             partial=False):
     """Calls `mask` on ``inner``, then returns the result of calling
     `embed` with ``outer`` and the result of `mask`.
 
@@ -791,8 +1004,13 @@ def forwards(outer, inner, num_args=0,
                 params.append(param.replace(default=None))
         inner = inner.replace(parameters=params)
     return embed(
-        use_varargs, use_varkwargs,
         outer,
         mask(inner, num_args,
-             hide_args, hide_kwargs, False, False,
-             *named_args))
+             *named_args,
+             hide_args=hide_args, hide_kwargs=hide_kwargs,
+             hide_varargs=False, hide_varkwargs=False,
+             _stacklevel=1,
+             ),
+        use_varargs=use_varargs, use_varkwargs=use_varkwargs,
+        _stacklevel=1,
+    )

--- a/sigtools/_specifiers.py
+++ b/sigtools/_specifiers.py
@@ -91,7 +91,7 @@ def forged_signature(obj, auto=True, args=(), kwargs={}):
     if forger is not None:
         ret = forger(obj=subject)
         if ret is not None:
-            return ret
+            return _signatures.UpgradedSignature._upgrade_with_warning(ret)
     if auto:
         try:
             subject._sigtools__autoforwards_hint
@@ -106,15 +106,17 @@ def forged_signature(obj, auto=True, args=(), kwargs={}):
                 except _autoforwards.UnknownForwards:
                     pass
                 else:
-                    return ret
+                    return _signatures.UpgradedSignature._upgrade_with_warning(ret)
             subject = _util.get_introspectable(subject, af_hint=False)
         try:
-            ret = _autoforwards.autoforwards(subject, args, kwargs)
+            ret = _signatures.UpgradedSignature._upgrade_with_warning(
+                _autoforwards.autoforwards(subject, args, kwargs)
+            )
         except _autoforwards.UnknownForwards:
             pass
         else:
-            return ret
-    return _signatures.signature(obj)
+            return _signatures.UpgradedSignature._upgrade_with_warning(ret)
+    return _signatures.UpgradedSignature._upgrade_with_warning(_signatures.signature(obj))
 
 
 from sigtools import _autoforwards

--- a/sigtools/modifiers.py
+++ b/sigtools/modifiers.py
@@ -354,8 +354,12 @@ class annotate(object):
         to_use = self.to_use.copy()
         for name, parameter in sig.parameters.items():
             if name in self.annotations:
+                annotation = self.annotations[name]
+                upgraded_annotation = _signatures.UpgradedAnnotation.preevaluated(annotation)
                 parameters.append(parameter.replace(
-                    annotation=self.annotations[name]))
+                    annotation=annotation,
+                    upgraded_annotation=upgraded_annotation,
+                ))
                 to_use.remove(name)
             else:
                 parameters.append(parameter)
@@ -368,7 +372,8 @@ class annotate(object):
             sig = sig.replace(parameters=parameters)
         else:
             sig = sig.replace(parameters=parameters,
-                              return_annotation=self.ret)
+                              return_annotation=self.ret,
+                              upgraded_return_annotation=_signatures.UpgradedAnnotation.preevaluated(self.ret))
         func.__signature__ = sig
         for pok in reversed(poks):
             pok._prepare()

--- a/sigtools/signatures.py
+++ b/sigtools/signatures.py
@@ -30,7 +30,6 @@ individually. They are most notably used by the decorators from
 
 """
 
-from sigtools import modifiers
 from sigtools._signatures import (
     signature,
     IncompatibleSignatures,
@@ -43,9 +42,3 @@ __all__ = [
     'merge', 'embed', 'mask', 'forwards', 'IncompatibleSignatures',
     'sort_params', 'apply_params',
     ]
-
-
-merge = modifiers.autokwoargs(merge)
-embed = modifiers.autokwoargs(embed)
-mask = modifiers.autokwoargs(exceptions=('num_args',))(mask)
-forwards = modifiers.autokwoargs(exceptions=('num_args',))(forwards)

--- a/sigtools/signatures.py
+++ b/sigtools/signatures.py
@@ -33,6 +33,7 @@ individually. They are most notably used by the decorators from
 from sigtools._signatures import (
     signature,
     IncompatibleSignatures,
+    UpgradedSignature, UpgradedParameter, UpgradedAnnotation,
     sort_params, apply_params,
     merge, embed, mask, forwards
     )
@@ -40,5 +41,6 @@ from sigtools._signatures import (
 __all__ = [
     'signature',
     'merge', 'embed', 'mask', 'forwards', 'IncompatibleSignatures',
+    'UpgradedSignature', 'UpgradedParameter', 'UpgradedAnnotation',
     'sort_params', 'apply_params',
     ]

--- a/sigtools/tests/test_autoforwards.py
+++ b/sigtools/tests/test_autoforwards.py
@@ -41,7 +41,7 @@ class AutoforwardsTests(Fixtures):
         self.assertSigsEqual(sig, support.s(expected))
         self.assertSourcesEqual(sig.sources, sources, func)
         if not incoherent:
-            support.test_func_sig_coherent(
+            support.assert_func_sig_coherent(
                 func, check_return=False, check_invalid=False)
 
     @tup('a, b, x, y, *, z',
@@ -141,7 +141,7 @@ class AutoforwardsTests(Fixtures):
             'x': [_wrapped], 'y': [_wrapped], 'z': [_wrapped],
             '+depths': {func: 0, _wrapper: 1, _wrapped: 2}
         })
-        support.test_func_sig_coherent(
+        support.assert_func_sig_coherent(
             func, check_return=False, check_invalid=False)
 
     @staticmethod
@@ -257,7 +257,7 @@ class AutoforwardsTests(Fixtures):
             'a': [func],
             'y': [_wrapped], 'z': [_wrapped]
         })
-        support.test_func_sig_coherent(
+        support.assert_func_sig_coherent(
             func, check_return=False, check_invalid=False)
 
     def test_decorator_wraps(self):
@@ -275,7 +275,7 @@ class AutoforwardsTests(Fixtures):
             'a': [func], 'b': [func],
             'y': [_wrapped], 'z': [_wrapped]
         })
-        support.test_func_sig_coherent(
+        support.assert_func_sig_coherent(
             func, check_return=False, check_invalid=False)
 
     @tup('a, b, *args, z',
@@ -319,7 +319,7 @@ class UnresolvableAutoforwardsTests(Fixtures):
             signatures.signature(func))
         if ensure_incoherent:
             with self.assertRaises(AssertionError):
-                support.test_func_sig_coherent(
+                support.assert_func_sig_coherent(
                     func, check_return=False, check_invalid=False)
 
     @tup(False)
@@ -493,7 +493,7 @@ class UnresolvableAutoforwardsWithSourcesTests(Fixtures):
         self.assertSigsEqual(sig, support.s(expected))
         self.assertSourcesEqual(sig.sources, expected_src, func)
         with self.assertRaises(AssertionError):
-            support.test_func_sig_coherent(
+            support.assert_func_sig_coherent(
                 func, check_return=False, check_invalid=False)
 
     @tup('v, w, *a, **k', {0: 'vwak'})

--- a/sigtools/tests/test_modifiers.py
+++ b/sigtools/tests/test_modifiers.py
@@ -25,8 +25,9 @@ from functools import wraps
 
 from sigtools import modifiers, specifiers
 from sigtools._util import funcsigs, safe_get
-from sigtools.support import test_func_sig_coherent, f, s, func_from_sig
+from sigtools.support import assert_func_sig_coherent, f, s, func_from_sig
 from sigtools.signatures import sort_params, apply_params, signature
+from sigtools._signatures import UpgradedParameter
 from sigtools.tests.util import Fixtures, SignatureTests
 
 
@@ -55,10 +56,10 @@ def defaults_variations(exp, orig):
 def insert_varargs(sig, args, kwargs):
     posargs, pokargs, varargs, kwoargs, varkwargs = sort_params(sig)
     if args:
-        varargs = funcsigs.Parameter(
+        varargs = UpgradedParameter(
             'args', funcsigs.Parameter.VAR_POSITIONAL)
     if kwargs:
-        varkwargs = funcsigs.Parameter(
+        varkwargs = UpgradedParameter(
             'kwargs', funcsigs.Parameter.VAR_KEYWORD)
     ret = apply_params(sig, posargs, pokargs, varargs, kwoargs, varkwargs)
     return ret
@@ -80,7 +81,7 @@ def poktranslator_test(self, expected_sig_str, orig_sig_str,
             func = modifiers._PokTranslator(
                 func_from_sig(orig), posoargs, kwoargs)
             self.assertSigsEqual(exp, signature(func))
-            test_func_sig_coherent(func)
+            assert_func_sig_coherent(func)
             repr(func) # must not cause an error
 
 

--- a/sigtools/tests/test_signatures.py
+++ b/sigtools/tests/test_signatures.py
@@ -188,6 +188,13 @@ class UpgradedSignatureTests(SignatureTests):
             s("a, b, c", 1)
         )
 
+    @unittest.skipIf(*python_doesnt_have_future_annotations)
+    def test_evaluated(self):
+        self.assertSigsEqual(
+            s("one: a", "ret", globals={"a": 1, "ret": 2}, future_features=["annotations"]).evaluated(),
+            s("one: 1", 2),
+        )
+
 
 class UpgradedParameterTests(SignatureTests):
     def test_upgrade_with_warning(self):
@@ -216,7 +223,7 @@ class UpgradedAnnotationTests(SignatureTests):
             UpgradedAnnotation.preevaluated(UpgradedParameter.empty)
         )
 
-    @unittest.skipIf(python_doesnt_have_future_annotations, "Py version doesn't have postponed annotations")
+    @unittest.skipIf(*python_doesnt_have_future_annotations)
     def test_upgrade_postponed_annotation(self):
         func = f("", globals={"value": "the value"}, future_features=["annotations"])
         self.assertEqual(

--- a/sigtools/tests/test_support.py
+++ b/sigtools/tests/test_support.py
@@ -21,11 +21,12 @@
 
 
 import sys
+import unittest
 
 from repeated_test import options
 
 from sigtools import support, _specifiers
-from sigtools.tests.util import Fixtures
+from sigtools.tests.util import Fixtures, python_has_future_annotations
 
 
 def remove_spaces(s):
@@ -107,6 +108,11 @@ class RoundTripTests(Fixtures):
         func = support.f('a, b, c', name='test_name')
         self._assert_equal_ignoring_spaces(func.__name__, 'test_name')
 
+    @unittest.skipUnless(python_has_future_annotations, "requires python with optional deferred annotations")
+    def test_deferred_annotations(self):
+        deferred = support.s('a: 1', future_features=("annotations",))
+        manually_deferred = support.s('a: "1"')
+        self._assert_equal_ignoring_spaces(str(manually_deferred), str(deferred))
 
 class FuncCodeTests(Fixtures):
     def _test(self, sig, expected_code, kwargs={}, *, min_version=None, max_version=None):

--- a/sigtools/tests/test_testutil.py
+++ b/sigtools/tests/test_testutil.py
@@ -160,12 +160,9 @@ class SignatureTestsTests(tutil.SignatureTests):
             self.assertSigsEqual(s('self, /, one'), s('self, *, one'),
                                  conv_first_posarg=True)
 
+    @unittest.skipIf(*tutil.python_doesnt_have_future_annotations)
     def test_sigs_equal_evaluated_annotation_different(self):
-        self.assertSigsEqual( # xcxc move this
-            s("one: a", globals={"a": 1}, future_features=["annotations"]).evaluated(),
-            s("one: 1"),
-        )
-        with self.assertRaisesRegex(AssertionError, "^.*(one: 2).*(one: 1).*$") as ar:
+        with self.assertRaisesRegex(AssertionError, "^.*(one: 2).*(one: 1).*$"):
             self.assertSigsEqual(
                 s("one: a", globals={"a": 1}, future_features=["annotations"]),
                 s("one: a", globals={"a": 2}, future_features=["annotations"]),

--- a/sigtools/tests/test_testutil.py
+++ b/sigtools/tests/test_testutil.py
@@ -160,6 +160,17 @@ class SignatureTestsTests(tutil.SignatureTests):
             self.assertSigsEqual(s('self, /, one'), s('self, *, one'),
                                  conv_first_posarg=True)
 
+    def test_sigs_equal_evaluated_annotation_different(self):
+        self.assertSigsEqual( # xcxc move this
+            s("one: a", globals={"a": 1}, future_features=["annotations"]).evaluated(),
+            s("one: 1"),
+        )
+        with self.assertRaisesRegex(AssertionError, "^.*(one: 2).*(one: 1).*$") as ar:
+            self.assertSigsEqual(
+                s("one: a", globals={"a": 1}, future_features=["annotations"]),
+                s("one: a", globals={"a": 2}, future_features=["annotations"]),
+            )
+
     def test_assertIs(self):
         self.assertIs(*([],)*2)
         with self.assertRaises(AssertionError):

--- a/sigtools/tests/util.py
+++ b/sigtools/tests/util.py
@@ -116,9 +116,9 @@ class SignatureTests(unittest.TestCase):
         conv = kwargs.pop('conv_first_posarg', False)
         if expected != found:
             def raise_assertion():
-                if self.downgrade_sig(found) != self.downgrade_sig(expected):
+                if self.downgrade_sig(found) == self.downgrade_sig(expected):
                     found_ev = found.evaluated()
-                    expected_ev = found.evaluated()
+                    expected_ev = expected.evaluated()
                     if found_ev != expected_ev:
                         raise AssertionError(
                             'Evaluated signatures are different: '
@@ -176,6 +176,8 @@ Fixtures = WithTestClass(SignatureTests)
 
 
 python_has_future_annotations = (3, 7, 0, "final") <= sys.version_info < (3, 11)
+python_has_annotations = (3, 11) <= sys.version_info
+python_doesnt_have_future_annotations = sys.version_info < (3, 7, 0, "final")
 
 
 def signature_not_using_future_annotations(*args, **kwargs):

--- a/sigtools/tests/util.py
+++ b/sigtools/tests/util.py
@@ -177,7 +177,10 @@ Fixtures = WithTestClass(SignatureTests)
 
 python_has_future_annotations = (3, 7, 0, "final") <= sys.version_info < (3, 11)
 python_has_annotations = (3, 11) <= sys.version_info
-python_doesnt_have_future_annotations = sys.version_info < (3, 7, 0, "final")
+python_doesnt_have_future_annotations = (
+    (sys.version_info < (3, 7, 0, "final")),
+    "Python version does not have __future__.annotations"
+)
 
 
 def signature_not_using_future_annotations(*args, **kwargs):

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,8 @@ skipsdist=true
 
 deps=
     .[tests]
+    pytest
+    pytest-subtests
     docs: -r docs/requirements.txt
     cover: coverage
 


### PR DESCRIPTION
This is intended to occur when the signature is read from a function.
If it occurs in other places, we issue a warning because the data would
be incomplete.

We store a reference to the annotation contents as well as the function
it originally occurred on, which is needed to evaluate postponed
annotations (PEP-563).